### PR TITLE
CLA0003-970 - Data Import On Demand

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,5 +4,4 @@ default['cookbook_clarus_worker']['efs']['region'] = 'eu-west-1'
 default['cookbook_clarus_worker']['papertrail']['destination_host'] = nil
 default['cookbook_clarus_worker']['papertrail']['destination_port'] = nil
 default['cookbook_clarus_worker']['app_root'] = "/home/apps/#{node['cookbook_clarus_worker']['appname']}"
-default['cookbook_clarus_worker']['shared_root'] = "#{node['cookbook_clarus_worker']['app_root']}/shared"
-default['cookbook_clarus_worker']['ftp_root'] = "#{node['cookbook_clarus_worker']['shared_root']}/storage"
+default['cookbook_clarus_worker']['ftp_root'] = '/home/apps/storage'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'fred.thompson@clarussoftware.co.uk'
 license          'Apache 2.0'
 description      'The Clarus worker cookbook, running resque.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.0.4'
+version          '0.0.5'
 
 recipe 'cookbook_clarus_worker', 'The Clarus worker cookbook, running resque.'
 

--- a/recipes/directories.rb
+++ b/recipes/directories.rb
@@ -14,3 +14,12 @@ directory app_root do
   action :create
   recursive true
 end
+
+# Create the base location for the storage ftp files
+directory ftp_root do
+  owner deploy_user
+  group deploy_user
+  mode '0755'
+  action :create
+  recursive true
+end

--- a/recipes/efs.rb
+++ b/recipes/efs.rb
@@ -5,30 +5,7 @@
 
 fsid = node['cookbook_clarus_worker']['efs']['fsid']
 region = node['cookbook_clarus_worker']['efs']['region']
-shared_root = node['cookbook_clarus_worker']['shared_root']
 ftp_root = node['cookbook_clarus_worker']['ftp_root']
-deploy_user = node['appbox']['deploy_user']
-
-# Create the base location for the shared files
-directory shared_root do
-  owner deploy_user
-  group deploy_user
-  mode '0755'
-  action :create
-  recursive true
-end
-
-# Create the base location for the FTP
-# We need to create this separately to the shared files location
-# as the owner and group only apply to the leaf node when
-# performing a recursive directory creation.
-directory ftp_root do
-  owner deploy_user
-  group deploy_user
-  mode '0755'
-  action :create
-  recursive true
-end
 
 # If we have a File Storage ID for FTP, then mount EFS to it.
 if fsid


### PR DESCRIPTION
Well, functionally got it right first time, but didnt account for the files that are imported are within an app named api and then they're processed by an app named worker, so the fil path doesn't match.

Solved this by moving the EFS storage out to app level and named it storage, on both api and worker.